### PR TITLE
Fix get schema attribute test failure by calling get_additional_schema_info instead of get_schema_def

### DIFF
--- a/native-schema-registry/c/test/glue_schema_registry_schema_test.c
+++ b/native-schema-registry/c/test/glue_schema_registry_schema_test.c
@@ -66,7 +66,7 @@ static void glue_schema_registry_schema_get_attribute_tests(void **state) {
     assert_string_equal(TEST_DATA_FORMAT, glue_schema_registry_schema_get_data_format(gsr_schema));
     assert_string_equal(TEST_SCHEMA_NAME, glue_schema_registry_schema_get_schema_name(gsr_schema));
     assert_string_equal(TEST_SCHEMA_DEF, glue_schema_registry_schema_get_schema_def(gsr_schema));
-    assert_string_equal(TEST_ADDITIONAL_SCHEMA_INFO, glue_schema_registry_schema_get_schema_def(gsr_schema));
+    assert_string_equal(TEST_ADDITIONAL_SCHEMA_INFO, glue_schema_registry_schema_get_additional_schema_info(gsr_schema));
 
     delete_glue_schema_registry_error_holder(p_err);
     schema_cleanup(gsr_schema);


### PR DESCRIPTION
Fix get schema attribute test failure by calling get_additional_schema_info instead of get_schema_def.

**Initial error**

```
RUN      ] glue_schema_registry_schema_get_attribute_tests
[  ERROR   ] --- "Some.Descriptor.Fullname" != "message Employee { string name = 1; int32 rank = 2;}"
[   LINE   ] --- /home/ubuntu/workplace/aws-glue-schema-registry/native-schema-registry/c/test/glue_schema_registry_schema_test.c:69: error: Failure!
[  FAILED  ] glue_schema_registry_schema_get_attribute_tests
```


**After the fix is pushed**
![Screenshot 2025-06-30 at 9 07 58 PM](https://github.com/user-attachments/assets/a166a05b-e389-47a3-b8bf-c8338c9095d9)
